### PR TITLE
Update SetPropertyValue method for Xamarin.Forms

### DIFF
--- a/Tizen.Appium.Forms/VisualElementWrapper.cs
+++ b/Tizen.Appium.Forms/VisualElementWrapper.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Reflection;
+using System.Linq;
 using Xamarin.Forms;
 using Xamarin.Forms.Platform.Tizen;
 using ElmSharp;
@@ -95,6 +97,20 @@ namespace Tizen.Appium.Forms
                     Deleted?.Invoke(this, EventArgs.Empty);
                 };
             }
+        }
+
+        protected override object ConvertValue(Type type, object value)
+        {
+            if (!type.IsPrimitive && type != typeof(string))
+            {
+                var converter = FormsAdapter.TypeConverters.FirstOrDefault(kvp => kvp.Key.Contains(type.Name)).Value;
+                if (converter != null)
+                {
+                    return converter.ConvertFromInvariantString(value.ToString());
+                }
+            }
+
+            return base.ConvertValue(type, value);
         }
     }
 }

--- a/Tizen.Appium.Shared/AppAdapter/BaseObjectWrapper.cs
+++ b/Tizen.Appium.Shared/AppAdapter/BaseObjectWrapper.cs
@@ -64,8 +64,7 @@ namespace Tizen.Appium
 
                 try
                 {
-                    var valueType = property.GetValue(Control).GetType();
-                    var convertedValue = Convert.ChangeType(value, valueType);
+                    var convertedValue = ConvertValue(property.PropertyType, value);
                     property.SetValue(Control, convertedValue);
                 }
                 catch (Exception e)
@@ -76,6 +75,11 @@ namespace Tizen.Appium
 
                 return true;
             });
+        }
+
+        protected virtual object ConvertValue(Type type, object value)
+        {
+            return Convert.ChangeType(value, type);
         }
 
         public virtual bool ContainsText(string text)


### PR DESCRIPTION
This PR is to enhance `SetPropertyValue` to support `Xamarin.Forms` specific properties using `TypeConverter`.